### PR TITLE
fix: 修复 README 中 Star History 图表无法显示的问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ GSManager3/
 
 ## 📈 项目统计
 
-![Star History](https://api.star-history.com/svg?repos=GSManagerXZ/GameServerManager&type=Date)
+![Star History](https://star-history.dera.page/svg?repos=GSManagerXZ/GameServerManager&type=Date)
 
 ---
 


### PR DESCRIPTION
README 中的 Star History 项目统计图表当前因 GitHub stargazer API 限制而无法正常显示。本 PR 将图表地址更新为新的数据源，无需 API token 即可正常渲染，恢复项目统计图表的展示。