### PR TITLE
fix: 修复 Modrinth 网络检测的重定向误报

### DIFF
--- a/docs/网络检测功能说明.md
+++ b/docs/网络检测功能说明.md
@@ -31,11 +31,17 @@
 #### Modrinth
 - **Modrinth API**（api.modrinth.com）
   - 用途：搜索 Minecraft 整合包
+  - 检测地址：`https://api.modrinth.com/v2/tag/category`
   - 影响：无法搜索 MC 整合包
   
 - **Modrinth CDN**（cdn.modrinth.com）
   - 用途：下载 Minecraft 整合包
+  - 检测地址：`https://cdn.modrinth.com/data/P7dR8mSH/icon.png`（Fabric API 项目的小图标）
   - 影响：无法下载 MC 整合包
+
+两项使用实际 HTTPS 资源，并跟随最多 5 次 HTTP 重定向。10 秒超时覆盖 DNS、连接和整条跳转链。最终收到 2xx 响应头即记录延迟并关闭连接，不下载完整文件，也不回退到 TCP 80 端口。其他检测项维持原有行为。
+
+Modrinth 域名根路径可能返回 301/307 重定向；若把它们当作 HTTP 失败并继续检测 TCP 80，会在 HTTPS 正常、80 端口不可达的环境中产生误报。这里显示的是连接响应延迟，不是下载带宽。
 
 #### Minecraft
 - **Mojang 会话服务器**（sessionserver.mojang.com）
@@ -388,6 +394,7 @@ Body: { "url": "www.baidu.com", "id": "baidu" }
 
 ### 后端文件
 - `server/src/routes/network.ts` - 网络检测路由
+- `server/src/utils/httpPingWithRedirects.ts` - 显式启用的 HTTP 重定向检测
 - `server/src/routes/index.ts` - 路由注册
 - `server/src/index.ts` - 服务器主文件
 - `server/src/middleware/auth.ts` - 认证中间件
@@ -403,4 +410,3 @@ Body: { "url": "www.baidu.com", "id": "baidu" }
 如需修改或扩展网络检测功能，请参考以上技术实现部分，按照现有代码结构进行开发。
 
 ---
-

--- a/server/src/__tests__/http-ping-redirects.test.ts
+++ b/server/src/__tests__/http-ping-redirects.test.ts
@@ -1,0 +1,280 @@
+import http, { ClientRequest, IncomingMessage, Server, ServerResponse } from 'http'
+import { EventEmitter, once } from 'events'
+import { AddressInfo, Socket } from 'net'
+import { httpPingWithRedirects } from '../utils/httpPingWithRedirects.js'
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve: () => void
+  const promise = new Promise<void>((complete) => { resolve = complete })
+  return { promise, resolve }
+}
+
+function mockRequest(): ClientRequest {
+  const request = new EventEmitter() as ClientRequest
+  request.destroy = jest.fn(() => request)
+  return request
+}
+
+function mockResponse(statusCode: number, location?: string): IncomingMessage {
+  const response = new EventEmitter() as IncomingMessage
+  response.statusCode = statusCode
+  response.headers = location === undefined ? {} : { location }
+  response.destroy = jest.fn(() => response)
+  return response
+}
+
+type ResponseCallback = (response: IncomingMessage) => void
+
+describe('httpPingWithRedirects', () => {
+  let server: Server
+  let baseUrl: string
+  let handler: (request: IncomingMessage, response: ServerResponse) => void
+  const sockets = new Set<Socket>()
+
+  beforeAll(async () => {
+    server = http.createServer((request, response) => handler(request, response))
+    server.on('connection', (socket) => {
+      sockets.add(socket)
+      socket.on('close', () => sockets.delete(socket))
+    })
+    server.listen(0, '127.0.0.1')
+    await once(server, 'listening')
+    baseUrl = `http://127.0.0.1:${(server.address() as AddressInfo).port}`
+  })
+
+  beforeEach(() => {
+    handler = (_request, response) => response.end('ok')
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+    jest.useRealTimers()
+    // 清理失败断言可能留下的测试连接，避免影响其它测试。
+    for (const socket of sockets) socket.destroy()
+  })
+
+  afterAll(async () => {
+    server.close()
+    await once(server, 'close')
+  })
+
+  it('accepts HTTP 200 and sends an identifying user agent', async () => {
+    let userAgent: string | undefined
+    handler = (request, response) => {
+      userAgent = request.headers['user-agent']
+      response.end('ok')
+    }
+
+    const result = await httpPingWithRedirects(baseUrl)
+
+    expect(result.success).toBe(true)
+    expect(result.responseTime).toEqual(expect.any(Number))
+    expect(userAgent).toBe('GSManager-NetworkCheck/1.0')
+  })
+
+  it('reports an HTTP 404 with its status detail', async () => {
+    handler = (_request, response) => {
+      response.writeHead(404)
+      response.end()
+    }
+
+    await expect(httpPingWithRedirects(baseUrl)).resolves.toEqual({
+      success: false,
+      error: 'HTTP状态码异常: 404，期望 2xx'
+    })
+  })
+
+  it('respects a custom expected status', async () => {
+    handler = (_request, response) => {
+      response.writeHead(204)
+      response.end()
+    }
+
+    expect((await httpPingWithRedirects(baseUrl, 1000, 204)).success).toBe(true)
+    await expect(httpPingWithRedirects(baseUrl, 1000, 200)).resolves.toEqual({
+      success: false,
+      error: 'HTTP状态码异常: 204，期望 200'
+    })
+  })
+
+  it.each([301, 302, 303, 307, 308])('follows a relative HTTP %i redirect', async (status) => {
+    const paths: string[] = []
+    handler = (request, response) => {
+      paths.push(request.url)
+      if (request.url === '/path/start') {
+        response.writeHead(status, { Location: '../ok' })
+      }
+      response.end()
+    }
+
+    expect((await httpPingWithRedirects(`${baseUrl}/path/start`)).success).toBe(true)
+    expect(paths).toEqual(['/path/start', '/ok'])
+  })
+
+  it('allows five redirects and rejects a sixth without making another request', async () => {
+    const paths: string[] = []
+    handler = (request, response) => {
+      paths.push(request.url)
+      const remaining = Number(request.url.slice(1))
+      if (remaining > 0) response.writeHead(302, { Location: `/${remaining - 1}` })
+      response.end()
+    }
+
+    expect((await httpPingWithRedirects(`${baseUrl}/5`)).success).toBe(true)
+    expect(paths).toEqual(['/5', '/4', '/3', '/2', '/1', '/0'])
+    paths.length = 0
+    await expect(httpPingWithRedirects(`${baseUrl}/6`)).resolves.toEqual({
+      success: false,
+      error: '重定向次数超过限制 (5)'
+    })
+    expect(paths).toEqual(['/6', '/5', '/4', '/3', '/2', '/1'])
+  })
+
+  it('bounds a redirect loop', async () => {
+    let requests = 0
+    handler = (_request, response) => {
+      requests++
+      response.writeHead(302, { Location: '/loop' })
+      response.end()
+    }
+
+    expect((await httpPingWithRedirects(`${baseUrl}/loop`)).error).toMatch(/重定向次数/)
+    expect(requests).toBe(6)
+  })
+
+  it('reports missing and malformed redirect locations', async () => {
+    handler = (request, response) => {
+      response.writeHead(302, request.url === '/missing' ? {} : { Location: 'http://[::1' })
+      response.end()
+    }
+
+    expect((await httpPingWithRedirects(`${baseUrl}/missing`)).error).toMatch(/缺少 Location/)
+    expect((await httpPingWithRedirects(`${baseUrl}/malformed`)).error).toMatch(/无效的重定向地址/)
+  })
+
+  it('rejects non-HTTP protocols initially and after a redirect', async () => {
+    handler = (_request, response) => {
+      response.writeHead(302, { Location: 'file:///test-file' })
+      response.end()
+    }
+
+    expect((await httpPingWithRedirects('file:///test-file')).error).toMatch(/不支持的 URL 协议/)
+    expect((await httpPingWithRedirects(baseUrl)).error).toMatch(/不支持的 URL 协议/)
+  })
+
+  it('shares one deadline across all redirect hops', async () => {
+    jest.useFakeTimers()
+    const callbacks: ResponseCallback[] = []
+    const requests: ClientRequest[] = []
+    jest.spyOn(http, 'get').mockImplementation((_url, _options, callback) => {
+      callbacks.push(callback)
+      const request = mockRequest()
+      requests.push(request)
+      return request
+    })
+
+    const pending = httpPingWithRedirects('http://example.test/start', 100)
+    await jest.advanceTimersByTimeAsync(60)
+    const redirect = mockResponse(307, '/next')
+    callbacks[0](redirect)
+    expect(requests).toHaveLength(2)
+    await jest.advanceTimersByTimeAsync(40)
+
+    await expect(pending).resolves.toEqual({ success: false, error: '连接超时 (100ms)' })
+    expect(redirect.destroy).toHaveBeenCalled()
+    expect(requests[0].destroy).toHaveBeenCalled()
+    expect(requests[1].destroy).toHaveBeenCalled()
+    expect(jest.getTimerCount()).toBe(0)
+  })
+
+  it('times out a connection without response headers and closes it', async () => {
+    const closed = deferred()
+    handler = (_request, response) => {
+      response.on('close', closed.resolve)
+    }
+
+    await expect(httpPingWithRedirects(baseUrl, 1000)).resolves.toEqual({
+      success: false,
+      error: '连接超时 (1000ms)'
+    })
+    await closed.promise
+  })
+
+  it('follows a redirect without waiting for an unfinished response body', async () => {
+    const closed = deferred()
+    handler = (request, response) => {
+      if (request.url === '/start') {
+        response.on('close', closed.resolve)
+        response.writeHead(307, { Location: '/ok' })
+        response.flushHeaders()
+      } else {
+        response.end('ok')
+      }
+    }
+
+    expect((await httpPingWithRedirects(`${baseUrl}/start`)).success).toBe(true)
+    await closed.promise
+  })
+
+  it('stops an unfinished successful response body after receiving headers', async () => {
+    const closed = deferred()
+    handler = (_request, response) => {
+      response.on('close', closed.resolve)
+      response.writeHead(200)
+      response.flushHeaders()
+    }
+
+    expect((await httpPingWithRedirects(baseUrl)).success).toBe(true)
+    await closed.promise
+  })
+
+  it('applies the deadline before a socket or DNS result is available', async () => {
+    jest.useFakeTimers()
+    const request = mockRequest()
+    jest.spyOn(http, 'get').mockReturnValue(request)
+
+    const pending = httpPingWithRedirects('http://unresolved.invalid/', 100)
+    await jest.advanceTimersByTimeAsync(100)
+
+    await expect(pending).resolves.toEqual({ success: false, error: '连接超时 (100ms)' })
+    expect(request.destroy).toHaveBeenCalled()
+    expect(jest.getTimerCount()).toBe(0)
+  })
+
+  it('ignores late errors from a retired redirect hop', async () => {
+    const callbacks: ResponseCallback[] = []
+    const requests: ClientRequest[] = []
+    jest.spyOn(http, 'get').mockImplementation((_url, _options, callback) => {
+      callbacks.push(callback)
+      const request = mockRequest()
+      requests.push(request)
+      return request
+    })
+
+    const pending = httpPingWithRedirects('http://example.test/start')
+    const redirect = mockResponse(307, '/ok')
+    callbacks[0](redirect)
+    requests[0].emit('error', new Error('retired request'))
+    redirect.emit('error', new Error('retired response'))
+    const response = mockResponse(200)
+    callbacks[1](response)
+
+    await expect(pending).resolves.toEqual({ success: true, responseTime: expect.any(Number) })
+    requests[1].emit('error', new Error('already settled'))
+    expect(response.destroy).toHaveBeenCalled()
+    expect(requests[1].destroy).toHaveBeenCalled()
+  })
+
+  it('leaves no open connection after a successful probe', async () => {
+    const closed = deferred()
+    handler = (request, response) => {
+      request.socket.on('close', closed.resolve)
+      response.writeHead(200)
+      response.flushHeaders()
+    }
+
+    expect((await httpPingWithRedirects(baseUrl)).success).toBe(true)
+    await closed.promise
+    expect(sockets.size).toBe(0)
+  })
+})

--- a/server/src/__tests__/network-modrinth.test.ts
+++ b/server/src/__tests__/network-modrinth.test.ts
@@ -1,0 +1,124 @@
+import { EventEmitter } from 'events'
+import { Readable } from 'stream'
+import http from 'http'
+import https from 'https'
+import type { Request, Response } from 'express'
+import networkRouter from '../routes/network.js'
+
+jest.mock('../middleware/auth.js', () => ({ authenticateToken: jest.fn() }))
+
+const mockTcpConnections: Array<{ host: string; port: number }> = []
+jest.mock('net', () => ({
+  __esModule: true,
+  default: {
+    Socket: class extends require('events').EventEmitter {
+      setTimeout() { return this }
+      destroy() { return this }
+      connect(port: number, host: string, onConnect: () => void) {
+        mockTcpConnections.push({ host, port })
+        queueMicrotask(() => {
+          if (port === 80) this.emit('error', new Error('TCP port 80 is blocked'))
+          else onConnect()
+        })
+        return this
+      }
+    }
+  }
+}))
+
+// Run the actual registered route handler; HTTP and TCP transports are local
+// fixtures so this regression does not depend on public services or DNS.
+async function check(path: '/check-single' | '/check-all', body = {}) {
+  const route = networkRouter.stack.find(layer => layer.route?.path === path).route
+  const handler = route.stack[route.stack.length - 1].handle
+  const response = { json: jest.fn(), status: jest.fn() }
+  response.status.mockReturnValue(response)
+  await handler({ body } as Request, response as unknown as Response, jest.fn())
+  expect(response.status).not.toHaveBeenCalled()
+  return response.json.mock.calls[0][0]
+}
+
+describe('Modrinth network checks', () => {
+  const requests: string[] = []
+  let apiStatus: number
+
+  beforeEach(() => {
+    requests.length = 0
+    mockTcpConnections.length = 0
+    apiStatus = 200
+
+    const get = (url: string | URL, _options: http.RequestOptions, callback: (res: http.IncomingMessage) => void) => {
+      const target = new URL(url)
+      requests.push(target.toString())
+      const request = Object.assign(new EventEmitter(), { destroy: jest.fn() })
+      queueMicrotask(() => {
+        let statusCode = 200
+        const headers: http.IncomingHttpHeaders = {}
+        if (target.hostname === 'api.modrinth.com') {
+          statusCode = target.pathname === '/v2/tag/category' ? apiStatus : 301
+          headers.location = 'https://docs.modrinth.com/'
+        } else if (target.hostname === 'cdn.modrinth.com') {
+          statusCode = 307
+          headers.location = `https://cdn-alt.modrinth.com${target.pathname}`
+        } else if (target.hostname === 'cdn-alt.modrinth.com' && target.pathname === '/') {
+          statusCode = 404
+        } else if (target.hostname === 'custom.example') {
+          statusCode = 302
+          headers.location = 'https://redirect.example/'
+        }
+        const response = Object.assign(Readable.from(['fixture']), { statusCode, headers })
+        callback(response as http.IncomingMessage)
+      })
+      return request as unknown as http.ClientRequest
+    }
+
+    jest.spyOn(https, 'get').mockImplementation(get as typeof https.get)
+    jest.spyOn(http, 'get').mockImplementation(get as typeof http.get)
+  })
+
+  afterEach(() => jest.restoreAllMocks())
+
+  it('checks the API resource when the client sends the legacy domain and item id', async () => {
+    const result = await check('/check-single', { id: 'modrinth-api', url: 'api.modrinth.com' })
+    expect(result.data).toMatchObject({ id: 'modrinth-api', status: 'success', responseTime: expect.any(Number) })
+    expect(requests).toEqual(['https://api.modrinth.com/v2/tag/category'])
+    expect(mockTcpConnections).toEqual([])
+  })
+
+  it('follows the CDN resource redirect instead of probing the domain root and TCP 80', async () => {
+    const result = await check('/check-single', { id: 'modrinth-cdn', url: 'cdn.modrinth.com' })
+    expect(result.data.status).toBe('success')
+    expect(requests).toEqual([
+      'https://cdn.modrinth.com/data/P7dR8mSH/icon.png',
+      'https://cdn-alt.modrinth.com/data/P7dR8mSH/icon.png'
+    ])
+    expect(mockTcpConnections).toEqual([])
+  })
+
+  it('preserves an actual API HTTP failure without replacing it with a TCP error', async () => {
+    apiStatus = 503
+    const result = await check('/check-single', { id: 'modrinth-api', url: 'api.modrinth.com' })
+    expect(result.data.status).toBe('failed')
+    expect(result.data.error).toContain('503')
+    expect(mockTcpConnections).toEqual([])
+  })
+
+  it('uses the same checks in check-all while retaining the other configured services', async () => {
+    const result = await check('/check-all')
+    expect(result.data.results).toHaveLength(9)
+    expect(result.data.results.every(item => item.status === 'success')).toBe(true)
+    expect(result.data.results.filter(item => item.id.startsWith('modrinth-'))).toEqual([
+      expect.objectContaining({ id: 'modrinth-api', url: 'https://api.modrinth.com/v2/tag/category', status: 'success' }),
+      expect.objectContaining({ id: 'modrinth-cdn', url: 'https://cdn.modrinth.com/data/P7dR8mSH/icon.png', status: 'success' })
+    ])
+    expect(mockTcpConnections).toEqual([{ host: 'langlangy2.server.xiaozhuhouses.asia', port: 44409 }])
+  })
+
+  it('leaves redirect behavior unchanged for custom checks without an opt-in', async () => {
+    const result = await check('/check-single', { url: 'https://custom.example/' })
+    expect(result.data.status).toBe('failed')
+    expect(result.data.error).toContain('302')
+    expect(requests).toEqual(['https://custom.example/'])
+    expect(mockTcpConnections).toEqual([])
+  })
+})

--- a/server/src/routes/network.ts
+++ b/server/src/routes/network.ts
@@ -4,6 +4,7 @@ import net from 'net'
 import http from 'http'
 import https from 'https'
 import { URL } from 'url'
+import { httpPingWithRedirects } from '../utils/httpPingWithRedirects.js'
 
 const router = Router()
 
@@ -18,6 +19,7 @@ interface NetworkCheckItem {
   checkType?: NetworkCheckType
   port?: number
   expectedStatusCode?: number
+  followRedirects?: boolean
   responseTime?: number
   errorMessage?: string
 }
@@ -29,8 +31,9 @@ const networkCheckItems: NetworkCheckItem[] = [
   { id: 'steamworks-api', name: 'Steamworks API(全球)', url: 'api.steampowered.com', status: 'pending' },
   { id: 'steamworks-partner', name: 'Steamworks API（合作/私有）', url: 'partner.steam-api.com', status: 'pending' },
   // Modrinth
-  { id: 'modrinth-api', name: 'Modrinth API', url: 'api.modrinth.com', status: 'pending' },
-  { id: 'modrinth-cdn', name: 'Modrinth CDN', url: 'cdn.modrinth.com', status: 'pending' },
+  // 根路径会返回重定向，使用实际资源并避免回退到无关的 TCP 80 检测。
+  { id: 'modrinth-api', name: 'Modrinth API', url: 'https://api.modrinth.com/v2/tag/category', status: 'pending', checkType: 'http', followRedirects: true },
+  { id: 'modrinth-cdn', name: 'Modrinth CDN', url: 'https://cdn.modrinth.com/data/P7dR8mSH/icon.png', status: 'pending', checkType: 'http', followRedirects: true },
   // Minecraft
   { id: 'mojang-session', name: 'Mojang 会话服务器', url: 'sessionserver.mojang.com', status: 'pending' },
   { id: 'msl-api', name: 'MSL API', url: 'https://api.mslmc.cn/v3', status: 'pending' },
@@ -184,7 +187,9 @@ async function checkItem(
   }
 
   if (item.checkType === 'http') {
-    return httpPing(item.url, timeout, item.expectedStatusCode)
+    return item.followRedirects
+      ? httpPingWithRedirects(item.url, timeout, item.expectedStatusCode)
+      : httpPing(item.url, timeout, item.expectedStatusCode)
   }
 
   return checkUrl(item.url, timeout, item.expectedStatusCode)
@@ -266,4 +271,3 @@ router.post('/check-single', authenticateToken, async (req: Request, res: Respon
 })
 
 export default router
-

--- a/server/src/utils/httpPingWithRedirects.ts
+++ b/server/src/utils/httpPingWithRedirects.ts
@@ -1,0 +1,133 @@
+import http, { ClientRequest, IncomingMessage } from 'http'
+import https from 'https'
+import { URL } from 'url'
+
+export interface HttpPingResult {
+  success: boolean
+  responseTime?: number
+  error?: string
+}
+
+/**
+ * 检测显式启用重定向的 HTTP 目标，整个跳转链共享一个总超时。
+ * 只读取响应头测量连接延迟，结束后关闭响应和连接，避免继续下载响应体。
+ */
+export function httpPingWithRedirects(
+  url: string,
+  timeout: number = 10000,
+  expectedStatusCode?: number
+): Promise<HttpPingResult> {
+  return new Promise((resolve) => {
+    const startTime = Date.now()
+    const maxRedirects = 5
+    let settled = false
+    let currentRequest: ClientRequest | undefined
+    let currentResponse: IncomingMessage | undefined
+
+    const finish = (result: HttpPingResult): void => {
+      if (settled) return
+      settled = true
+      clearTimeout(timeoutId)
+      currentResponse?.destroy()
+      currentRequest?.destroy()
+      resolve(result)
+    }
+    const timeoutResult = (): HttpPingResult => ({
+      success: false,
+      error: `连接超时 (${timeout}ms)`
+    })
+    const timeoutId = setTimeout(() => finish(timeoutResult()), timeout)
+
+    const visit = (target: string, redirectCount: number): void => {
+      if (settled) return
+      if (Date.now() - startTime >= timeout) {
+        finish(timeoutResult())
+        return
+      }
+
+      try {
+        const parsedUrl = new URL(target)
+        if (parsedUrl.protocol !== 'http:' && parsedUrl.protocol !== 'https:') {
+          finish({ success: false, error: `不支持的 URL 协议: ${parsedUrl.protocol}` })
+          return
+        }
+        const protocol = parsedUrl.protocol === 'https:' ? https : http
+        const request = protocol.get(parsedUrl.toString(), {
+          headers: { 'User-Agent': 'GSManager-NetworkCheck/1.0' }
+        }, (response) => {
+          if (settled || request !== currentRequest) {
+            response.on('error', () => {})
+            response.destroy()
+            return
+          }
+          currentResponse = response
+          response.on('error', (error: Error) => {
+            if (!settled && request === currentRequest) {
+              finish({ success: false, error: error.message })
+            }
+          })
+          if (Date.now() - startTime >= timeout) {
+            finish(timeoutResult())
+            return
+          }
+
+          const statusCode = response.statusCode ?? 0
+          if ([301, 302, 303, 307, 308].includes(statusCode)) {
+            const location = response.headers.location
+            if (!location) {
+              finish({ success: false, error: `HTTP 重定向缺少 Location: ${statusCode}` })
+              return
+            }
+            if (redirectCount >= maxRedirects) {
+              finish({ success: false, error: `重定向次数超过限制 (${maxRedirects})` })
+              return
+            }
+            let nextUrl: URL
+            try {
+              nextUrl = new URL(location, parsedUrl)
+            } catch (error) {
+              finish({ success: false, error: `无效的重定向地址: ${getErrorMessage(error)}` })
+              return
+            }
+            if (nextUrl.protocol !== 'http:' && nextUrl.protocol !== 'https:') {
+              finish({ success: false, error: `不支持的 URL 协议: ${nextUrl.protocol}` })
+              return
+            }
+            // 先结束当前跳，防止关闭旧连接产生的异步错误影响后续请求。
+            currentRequest = undefined
+            currentResponse = undefined
+            response.destroy()
+            request.destroy()
+            visit(nextUrl.toString(), redirectCount + 1)
+            return
+          }
+
+          const isStatusValid = expectedStatusCode !== undefined
+            ? statusCode === expectedStatusCode
+            : statusCode >= 200 && statusCode < 300
+          if (isStatusValid) {
+            finish({ success: true, responseTime: Date.now() - startTime })
+            return
+          }
+          const expectedLabel = expectedStatusCode !== undefined
+            ? `，期望 ${expectedStatusCode}` : '，期望 2xx'
+          finish({ success: false, error: `HTTP状态码异常: ${statusCode}${expectedLabel}` })
+        })
+        currentRequest = request
+        request.on('error', (error: Error) => {
+          if (!settled && request === currentRequest) {
+            finish({ success: false, error: error.message })
+          }
+        })
+      } catch (error) {
+        finish({ success: false, error: getErrorMessage(error) })
+      }
+    }
+
+    visit(url, 0)
+  })
+}
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}


### PR DESCRIPTION
Modrinth API/CDN 的根路径分别会返回 301/307 重定向。原检测只接受 2xx，随后回退到 TCP 80：在 HTTPS 可用但 80 端口不可达的环境中，两项都会被误报为连接超时，并丢失原始 HTTP 错误。

本次将两项检测改为实际 HTTPS 资源：API 的 `/v2/tag/category` 和 CDN 的 Fabric API 小图标。仅这两项启用重定向处理，最多跟随 5 次跳转，DNS、连接和整条跳转链共用 10 秒超时；收到最终响应头后记录延迟并关闭连接，保留真实 HTTP 失败，不再回退 TCP 80。单项检测兼容现有客户端发送的域名及 ID，全量检测使用同一逻辑，其他服务检测行为不变。

验证：

- `cd server && npm run build` 通过。
- `cd server && npm test -- --runInBand src/__tests__/network-modrinth.test.ts src/__tests__/http-ping-redirects.test.ts`：2 个测试套件、24 项测试全部通过。
- 路由回归在修复前复现 4 项失败，修复后全部通过。
- 回归覆盖单项/全量检测、真实 HTTP 错误、相对重定向、跳转循环与上限、整链总超时、DNS 阶段挂起、旧请求异步错误隔离及连接清理；自动化测试不访问外网。
- 更新网络检测文档，说明实际检测地址及响应延迟的含义。
